### PR TITLE
Add support for Kotlin files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ sudo gem install danger-jacoco
 Add 
 
 ```ruby
-jacoco.minimum_coverage_percentage=80
+jacoco.minimum_project_coverage_percentage = 50 # default 0
+jacoco.minimum_class_coverage_percentage = 75 # default 0
+jacoco.files_extension = [".java"] # default [".kt", ".java"]
 jacoco.report "path/to/jacoco.xml"
 ```
 

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -3,7 +3,7 @@ require 'jacoco/sax_parser'
 module Danger
   #
   # @see  Anton Malinskiy/danger-jacoco
-  # @tags jacoco, coverage, java, android
+  # @tags jacoco, coverage, java, android, kotlin
   #
   class DangerJacoco < Plugin
     attr_accessor :minimum_project_coverage_percentage
@@ -30,20 +30,22 @@ module Danger
     #
     # @path path to the xml output of jacoco
     # @delimiter git.modified_files returns full paths to the
-    # changed files. We need to get the java class from this path to check the
+    # changed files. We need to get the class from this path to check the
     # Jacoco report,
     #
-    # e.g. src/java/com/example/SomeClass.java -> com/example/SomeClass
+    # e.g. src/java/com/example/SomeJavaClass.java -> com/example/SomeJavaClass
+    # e.g. src/kotlin/com/example/SomeKotlinClass.kt -> com/example/SomeKotlinClass
     #
     # The default value supposes that you're using gradle structure,
-    # that is your path to java source files is something like
+    # that is your path to source files is something like
     #
-    # blah/blah/java/slashed_package/Source.java
+    # Java => blah/blah/java/slashed_package/Source.java
+    # Kotlin => blah/blah/kotlin/slashed_package/Source.kt
     #
-    def report(path, delimiter = '/java/')
+    def report(path, delimiter = /\/java\/|\/kotlin\//)
       setup
       classes = classes(delimiter)
-      # puts delimiter
+
       parser = Jacoco::SAXParser.new(classes)
       Nokogiri::XML::SAX::Parser.new(parser).parse(File.open(path))
       

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -12,8 +12,8 @@ module Danger
     attr_accessor :files_extension
 
     def setup
-      @minimum_project_coverage_percentage = 60 unless minimum_project_coverage_percentage
-      @minimum_class_coverage_percentage = 75 unless minimum_class_coverage_percentage
+      @minimum_project_coverage_percentage = 0 unless minimum_project_coverage_percentage
+      @minimum_class_coverage_percentage = 0 unless minimum_class_coverage_percentage
       @files_extension = [".kt",".java"] unless files_extension
     end
 

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -61,7 +61,7 @@ module Danger
 
       # fail danger if total coveraged is smaller than minimum_project_coverage_percentage
       if total_covered[:covered] < minimum_project_coverage_percentage
-        fail("Total coverage of #{total_covered[:covered]}%. Improve this to as least #{minimum_project_coverage_percentage}")
+        fail("Total coverage of #{total_covered[:covered]}%. Improve this to as least #{minimum_project_coverage_percentage} %")
       end
     end
 

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -50,7 +50,7 @@ module Danger
       total_covered = total_coverage(path)
 
       report_markdown = "### JaCoCO Code Coverage #{total_covered[:covered]}% #{total_covered[:status]}\n"
-      report_markdown << "| Classe | Coverage Atual | Meta | Status |\n"
+      report_markdown << "| Class | Covered | Meta | Status |\n"
       report_markdown << "|:---:|:---:|:---:|:---:|\n"
       parser.classes.each do |jacoco_class| # Check metrics for each classes
         rp = report_class(jacoco_class)

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -1,5 +1,4 @@
 require 'jacoco/sax_parser'
-require "oga"
 
 module Danger
   #
@@ -101,11 +100,11 @@ module Danger
 
     # It returns total of project code coverage and an emoji status as well
     def total_coverage(report_path)
-        jacoco_report = Oga.parse_xml(File.open(report_path))
+        jacoco_report = Nokogiri::XML(File.open(report_path))
         
-        report = jacoco_report.xpath('report/counter').select { |item| item.get('type') == "INSTRUCTION" }
-        missed_instructions = report.first.get('missed').to_f
-        covered_instructions = report.first.get('covered').to_f
+        report = jacoco_report.xpath('report/counter').select { |item| item['type'] == "INSTRUCTION" }
+        missed_instructions = report.first['missed'].to_f
+        covered_instructions = report.first['covered'].to_f
         total_instructions = missed_instructions + covered_instructions
         covered_percentage = (covered_instructions * 100 / total_instructions).round(2)
         coverage_status = coverage_status(covered_percentage, minimum_project_coverage_percentage)

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -1,4 +1,5 @@
 require 'jacoco/sax_parser'
+require "oga"
 
 module Danger
   #
@@ -6,7 +7,16 @@ module Danger
   # @tags jacoco, coverage, java, android
   #
   class DangerJacoco < Plugin
-    attr_accessor :minimum_coverage_percentage
+    attr_accessor :minimum_project_coverage_percentage
+    attr_accessor :minimum_class_coverage_percentage
+    attr_accessor :files_extension
+
+    def setup
+      @minimum_project_coverage_percentage = 60 unless minimum_project_coverage_percentage
+      @minimum_class_coverage_percentage = 75 unless minimum_class_coverage_percentage
+      @files_extension = [".kt",".java"] unless files_extension
+    end
+
 
     # Parses the xml output of jacoco to Ruby model classes
     # This is slow since it's basically DOM parsing
@@ -32,46 +42,78 @@ module Danger
     # blah/blah/java/slashed_package/Source.java
     #
     def report(path, delimiter = '/java/')
+      setup
       classes = classes(delimiter)
-
+      # puts delimiter
       parser = Jacoco::SAXParser.new(classes)
       Nokogiri::XML::SAX::Parser.new(parser).parse(File.open(path))
+      
+      total_covered = total_coverage(path)
 
-      parser.classes.each do |jacoco_class|
-        # Check which metrics are available
-        report_class(jacoco_class)
+      report_markdown = "### JaCoCO Code Coverage #{total_covered[:covered]}% #{total_covered[:status]}\n"
+      report_markdown << "| Classe | Coverage Atual | Meta | Status |\n"
+      report_markdown << "|:---:|:---:|:---:|:---:|\n"
+      parser.classes.each do |jacoco_class| # Check metrics for each classes
+        rp = report_class(jacoco_class)
+        report_markdown << "| `#{jacoco_class.name}` | #{rp[:covered]}% | #{minimum_class_coverage_percentage}% | #{rp[:status]} |\n"
+      end  
+      markdown(report_markdown)
+
+      # fail danger if total coveraged is smaller than minimum_project_coverage_percentage
+      if total_covered[:covered] < minimum_project_coverage_percentage
+        fail("Total coverage of #{total_covered[:covered]}%. Improve this to as least #{minimum_project_coverage_percentage}")
       end
     end
 
+    # Select modified and added files in this PR
     def classes(delimiter)
       git = @dangerfile.git
       affected_files = git.modified_files + git.added_files
-      affected_files.select { |file| file.end_with? '.java' }
-                    .map { |file| extract_class(file, delimiter) }
+      affected_files.select { |file| files_extension.reduce(false) { |state, el| state or file.end_with?(el) } }
+                    .map { |file| file.split(".").first.split(delimiter)[1] }
     end
 
+    # It returns a specific class code coverage and an emoji status as well
     def report_class(jacoco_class)
+      
       counters       = jacoco_class.counters
       branch_counter = counters.detect { |e| e.type.eql? 'BRANCH' }
       line_counter   = counters.detect { |e| e.type.eql? 'LINE' }
       counter        = branch_counter.nil? ? line_counter : branch_counter
-
-      report_counter(counter, jacoco_class)
+      coverage = (counter.covered.fdiv(counter.covered + counter.missed) * 100).floor
+      status = coverage_status(coverage, minimum_class_coverage_percentage)
+      
+      return {
+        covered: coverage,
+        status: status
+      }
+      
     end
 
-    def report_counter(counter, jacoco_class)
-      covered  = counter.covered
-      missed   = counter.missed
-      coverage = (covered.fdiv(covered + missed) * 100).floor
-
-      return unless coverage < minimum_coverage_percentage
-
-      fail("#{jacoco_class.name} has coverage of #{coverage}%. " \
-              "Improve this to at least #{minimum_coverage_percentage}%")
+    # it returns an emoji for coverage status
+    def coverage_status(coverage, minimum_percentage)
+      return case
+      when coverage < (minimum_percentage/2);  ":skull:"
+      when coverage < minimum_percentage;  ":warning:"
+      else ":white_check_mark:"
+      end
     end
 
-    def extract_class(file, java_path_delimiter)
-      file[0, file.length - 5].split(java_path_delimiter)[1]
+    # It returns total of project code coverage and an emoji status as well
+    def total_coverage(report_path)
+        jacoco_report = Oga.parse_xml(File.open(report_path))
+        
+        report = jacoco_report.xpath('report/counter').select { |item| item.get('type') == "INSTRUCTION" }
+        missed_instructions = report.first.get('missed').to_f
+        covered_instructions = report.first.get('covered').to_f
+        total_instructions = missed_instructions + covered_instructions
+        covered_percentage = (covered_instructions * 100 / total_instructions).round(2)
+        coverage_status = coverage_status(covered_percentage, minimum_project_coverage_percentage)
+
+        return {
+          covered: covered_percentage,
+          status: coverage_status
+        }
     end
   end
 end


### PR DESCRIPTION
This PR add support for Kotlin files. Also I've changed de report message to show the coverage of whole project and the coverage of each modified/added class. 

Besides that, I've included default params to this plugin:
```ruby
jacoco.minimum_project_coverage_percentage = 50 # default 0
jacoco.minimum_class_coverage_percentage = 75 # default 0
jacoco.files_extension = [".java"] # default [".kt", ".java"]
jacoco.report "path/to/jacoco.xml"
```
I not sure about it, but i guess that with `jacoco.files_extension` maybe will work for other Java based langs such as Scala, Groovy.

Here an example of report message:
![screen shot 2018-03-02 at 09 13 13](https://user-images.githubusercontent.com/6514332/36898532-fed1327e-1df9-11e8-82a1-b8eb44538250.png)

As you can see in report message, I added an emoji status based on `minimum_project_coverage_percentage` and `minimum_class_coverage_percentage`. There are three status: 
-  :skull: for a realy bad code coverage (less than half of `minimum_percentage`)
- :warning: when covered percentage is less than `minimum_percentage`
- :white_check_mark: when covered percentage is greater than `minimum_percentage`

