### PR TITLE
Add file specific coverage and also re-write spec unit tests

### DIFF
--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -65,9 +65,8 @@ module Danger
     def classes(delimiter)
       git = @dangerfile.git
       affected_files = git.modified_files + git.added_files
-      result = affected_files.select { |file| files_extension.reduce(false) { |state, el| state || file.end_with?(el) } }
+      affected_files.select { |file| files_extension.reduce(false) { |state, el| state || file.end_with?(el) } }
                     .map { |file| file.split('.').first.split(delimiter)[1] }
-      result
     end
 
     # It returns a specific class code coverage and an emoji status as well

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -66,7 +66,7 @@ module Danger
       git = @dangerfile.git
       affected_files = git.modified_files + git.added_files
       result = affected_files.select { |file| files_extension.reduce(false) { |state, el| state || file.end_with?(el) } }
-                    .map { |file| file.split('.').first.split(delimiter)[0] }
+                    .map { |file| file.split('.').first.split(delimiter)[1] }
       result
     end
 

--- a/spec/fixtures/output_a.xml
+++ b/spec/fixtures/output_a.xml
@@ -3,7 +3,7 @@
 <report name="test_report">
   <sessioninfo id="test-id" start="1480057517395" dump="1480057526412"/>
   <package name="com/example">
-    <class name="com/example/MemoryCache">
+    <class name="com/example/CachedRepository">
       <method name="&lt;init&gt;" desc="()V" line="17">
         <counter type="INSTRUCTION" missed="0" covered="11"/>
         <counter type="LINE" missed="0" covered="5"/>
@@ -12,18 +12,19 @@
       </method>
       <counter type="INSTRUCTION" missed="0" covered="46"/>
       <counter type="LINE" missed="0" covered="14"/>
-      <counter type="COMPLEXITY" missed="0" covered="7"/>
+      <counter type="COMPLEXITY" missed="5" covered="7"/>
       <counter type="METHOD" missed="0" covered="7"/>
       <counter type="CLASS" missed="0" covered="1"/>
+      <counter type="BRANCH" missed="2" covered="2" />
     </class>
     <sourcefile name="CachedRepository.java">
       <line nr="16" mi="0" ci="2" mb="0" cb="0"/>
       <line nr="17" mi="0" ci="3" mb="0" cb="0"/>
-      <counter type="INSTRUCTION" missed="0" covered="98"/>
-      <counter type="LINE" missed="0" covered="19"/>
-      <counter type="COMPLEXITY" missed="0" covered="11"/>
-      <counter type="METHOD" missed="0" covered="11"/>
-      <counter type="CLASS" missed="0" covered="4"/>
+      <counter type="INSTRUCTION" missed="2" covered="98"/>
+      <counter type="LINE" missed="2" covered="19"/>
+      <counter type="COMPLEXITY" missed="2" covered="11"/>
+      <counter type="METHOD" missed="2" covered="11"/>
+      <counter type="CLASS" missed="2" covered="4"/>
     </sourcefile>
     <counter type="INSTRUCTION" missed="80" covered="324"/>
     <counter type="BRANCH" missed="4" covered="4"/>

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -1,13 +1,46 @@
-require File.expand_path('../spec_helper', __FILE__)
+require File.expand_path("../spec_helper", __FILE__)
 
-module Jacoco
-  describe Jacoco::DOMParser do
-    path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+module Danger
 
-    describe 'read xml' do
-      it 'reads report' do
-        Jacoco::DOMParser.read_path(path_a)
+  describe Danger::DangerJacoco do
+    it "should be a plugin" do
+      expect(Danger::DangerJacoco.new(nil)).to be_a Danger::Plugin
+    end
+
+    #
+    # You should test your custom attributes and methods here
+    #
+    describe "with Dangerfile" do
+      before do
+        @dangerfile = testing_dangerfile
+        @my_plugin = @dangerfile.jacoco
+
+        modified_files = ['com/example/CachedRepository.java']
+        added_files = ['Blah.java']
+
+        allow(@dangerfile.git).to receive(:modified_files).and_return(modified_files)
+        allow(@dangerfile.git).to receive(:added_files).and_return(added_files)
+
       end
+
+
+      it :report do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_project_coverage_percentage = 50
+        @my_plugin.minimum_class_coverage_map = { "com/example/CachedRepository" => 100}
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:errors]).to eq(["Total coverage of 32.9%. Improve this to at least 50%",
+                                                          "Class coverage is below minimum. Improve to at least 0%"])
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("### JaCoCO Code Coverage 32.9% :warning:")
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("| Class | Covered | Meta | Status |")
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("|:---:|:---:|:---:|:---:|")
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("| `com/example/CachedRepository` | 50% | 100% | :warning: |")
+
+      end
+
     end
   end
 end

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -15,8 +15,8 @@ module Danger
         @dangerfile = testing_dangerfile
         @my_plugin = @dangerfile.jacoco
 
-        modified_files = ['com/example/CachedRepository.java']
-        added_files = ['Blah.java']
+        modified_files = ['src/java/com/example/CachedRepository.java']
+        added_files = ['src/java/Blah.java']
 
         allow(@dangerfile.git).to receive(:modified_files).and_return(modified_files)
         allow(@dangerfile.git).to receive(:added_files).and_return(added_files)


### PR DESCRIPTION
I have a question with statement `.map { |file| file.split('.').first.split(delimiter)[1] }` , in this PR i have modified it to `.map { |file| file.split('.').first.split(delimiter)[0] }` because some inconceivable reason I could not think of a way to have the file name in the [1] index of the array, because you split a file with path `com/example/CachedRepo.java` the name part `com/example/cachedrepo` is bound to be in the [0] index, I want to understand how to write test without modifying this part because I dont know how this can affect production code.