### PR TITLE
Minimum package coverage map

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Add
 
 ```ruby
 jacoco.minimum_project_coverage_percentage = 50 # default 0
+jacoco.minimum_package_coverage_map = { # default is empty
+  'com/package/' => 55,
+  'com/package/more/specific/' => 15
+}
 jacoco.minimum_class_coverage_percentage = 75 # default 0
 jacoco.files_extension = [".java"] # default [".kt", ".java"]
 jacoco.report("path/to/jacoco.xml", "http://jacoco-html-reports/")

--- a/README.md
+++ b/README.md
@@ -15,9 +15,12 @@ Add
 
 ```ruby
 jacoco.minimum_project_coverage_percentage = 50 # default 0
-jacoco.minimum_package_coverage_map = { # default is empty
+jacoco.minimum_package_coverage_map = { # optional (default is empty)
   'com/package/' => 55,
   'com/package/more/specific/' => 15
+}
+jacoco.minimum_class_coverage_map = { # optional (default is empty)
+  'com/package/more/specific/ClassName' => 15
 }
 jacoco.minimum_class_coverage_percentage = 75 # default 0
 jacoco.files_extension = [".java"] # default [".kt", ".java"]

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -103,6 +103,7 @@ module Danger
           return coverage
         end
       end
+      return nil
     end
 
     # it returns an emoji for coverage status

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -9,11 +9,13 @@ module Danger
     attr_accessor :minimum_project_coverage_percentage
     attr_accessor :minimum_class_coverage_percentage
     attr_accessor :files_extension
+    attr_accessor :minimum_package_coverage_map
     attr_accessor :minimum_class_coverage_map
 
     def setup
       @minimum_project_coverage_percentage = 0 unless minimum_project_coverage_percentage
       @minimum_class_coverage_percentage = 0 unless minimum_class_coverage_percentage
+      @minimum_package_coverage_map = {} unless minimum_package_coverage_map
       @minimum_class_coverage_map = {} unless minimum_class_coverage_map
       @files_extension = ['.kt', '.java'] unless files_extension
     end
@@ -75,6 +77,7 @@ module Danger
       counter = coverage_counter(jacoco_class)
       coverage = (counter.covered.fdiv(counter.covered + counter.missed) * 100).floor
       required_coverage = minimum_class_coverage_map[jacoco_class.name]
+      required_coverage = package_coverage(jacoco_class.name) if required_coverage.nil?
       required_coverage = minimum_class_coverage_percentage if required_coverage.nil?
       status = coverage_status(coverage, required_coverage)
 
@@ -83,6 +86,23 @@ module Danger
         status: status,
         required_coverage_percentage: required_coverage
       }
+    end
+
+    # it returns the most suitable coverage by package name to class or nil
+    def package_coverage(class_name)
+      path = class_name
+      package_parts = class_name.split('/')
+      package_parts.reverse_each do |item|
+        size = item.size
+        path = path[0...-size]
+        coverage = minimum_package_coverage_map[path]
+        if path.size > 0
+          path = path[0...-1]
+        end
+        if coverage != nil
+          return coverage
+        end
+      end
     end
 
     # it returns an emoji for coverage status

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -23,12 +23,11 @@ module Danger
 
       end
 
-
       it :report do
         path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
 
         @my_plugin.minimum_project_coverage_percentage = 50
-        @my_plugin.minimum_class_coverage_map = { "com/example/CachedRepository" => 100}
+        @my_plugin.minimum_class_coverage_map = { "com/example/CachedRepository" => 100 }
 
         @my_plugin.report path_a
 
@@ -38,6 +37,80 @@ module Danger
         expect(@dangerfile.status_report[:markdowns][0].message).to include("| Class | Covered | Meta | Status |")
         expect(@dangerfile.status_report[:markdowns][0].message).to include("|:---|:---:|:---:|:---:|")
         expect(@dangerfile.status_report[:markdowns][0].message).to include("| `com/example/CachedRepository` | 50% | 100% | :warning: |")
+
+      end
+
+      it 'test with package coverage' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_project_coverage_percentage = 50
+        @my_plugin.minimum_package_coverage_map = { "com/example/" => 70 }
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("| `com/example/CachedRepository` | 50% | 70% | :warning: |")
+
+      end
+
+      it 'test with bigger overlapped package coverage' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_project_coverage_percentage = 50
+        @my_plugin.minimum_package_coverage_map = {
+          "com/example/" => 70,
+          "com/" => 90
+        }
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("| `com/example/CachedRepository` | 50% | 70% | :warning: |")
+
+      end
+
+      it 'test with lower overlapped package coverage' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_project_coverage_percentage = 50
+        @my_plugin.minimum_package_coverage_map = {
+          "com/example/" => 77,
+          "com/" => 30
+        }
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("| `com/example/CachedRepository` | 50% | 77% | :warning: |")
+
+      end
+
+      it 'test with overlapped package coverage and bigger class coverage' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_project_coverage_percentage = 50
+        @my_plugin.minimum_package_coverage_map = {
+          "com/example/" => 77,
+          "com/" => 30
+        }
+        @my_plugin.minimum_class_coverage_map = { "com/example/CachedRepository" => 100 }
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("| `com/example/CachedRepository` | 50% | 100% | :warning: |")
+
+      end
+
+      it 'test with overlapped package coverage and lowwer class coverage' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_project_coverage_percentage = 50
+        @my_plugin.minimum_package_coverage_map = {
+          "com/example/" => 90,
+          "com/" => 85
+        }
+        @my_plugin.minimum_class_coverage_map = { "com/example/CachedRepository" => 80 }
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include("| `com/example/CachedRepository` | 50% | 80% | :warning: |")
 
       end
 
@@ -52,7 +125,7 @@ module Danger
         expect(@dangerfile.status_report[:markdowns][0].message).to include("| [`com/example/CachedRepository`](http://test.com/com.example/CachedRepository.html) | 50% | 80% | :warning: |")
 
       end
-    
+
     end
   end
 end


### PR DESCRIPTION
Added possibility to configure custom test coverage value for whole specific package.
E.g. added new package 'com/company/newmodule' and you need to add specific test coverage just for this package.  