### PR TITLE
Warn on empty node rather than raising error with an option

### DIFF
--- a/danger-jacoco.gemspec
+++ b/danger-jacoco.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'nokogiri-happymapper', '~> 0.6'
 
   # General ruby development
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.3'
 
   # Testing support

--- a/lib/jacoco/gem_version.rb
+++ b/lib/jacoco/gem_version.rb
@@ -1,3 +1,3 @@
 module Jacoco
-  VERSION = '0.1.4'.freeze
+  VERSION = '0.1.5'.freeze
 end

--- a/lib/jacoco/gem_version.rb
+++ b/lib/jacoco/gem_version.rb
@@ -1,3 +1,3 @@
 module Jacoco
-  VERSION = '0.1.5'.freeze
+  VERSION = '0.1.6'.freeze
 end

--- a/spec/fixtures/output_b.xml
+++ b/spec/fixtures/output_b.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><!DOCTYPE report PUBLIC "-//JACOCO//DTD Report 1.0//EN"
+        "report.dtd">
+<report name="test_report">
+  <sessioninfo id="test-id" start="1480057517395" dump="1480057526412"/>
+  <package name="com/example">
+    <class name="com/example/CachedRepository">
+      <method name="&lt;init&gt;" desc="()V" line="17">
+        <counter type="INSTRUCTION" missed="0" covered="11"/>
+        <counter type="COMPLEXITY" missed="0" covered="1"/>
+        <counter type="METHOD" missed="0" covered="1"/>
+      </method>
+      <counter type="INSTRUCTION" missed="0" covered="46"/>
+      <counter type="COMPLEXITY" missed="5" covered="7"/>
+      <counter type="METHOD" missed="0" covered="7"/>
+      <counter type="CLASS" missed="0" covered="1"/>
+    </class>
+    <sourcefile name="CachedRepository.java">
+      <line nr="16" mi="0" ci="2" mb="0" cb="0"/>
+      <line nr="17" mi="0" ci="3" mb="0" cb="0"/>
+      <counter type="INSTRUCTION" missed="2" covered="98"/>
+      <counter type="COMPLEXITY" missed="2" covered="11"/>
+      <counter type="METHOD" missed="2" covered="11"/>
+      <counter type="CLASS" missed="2" covered="4"/>
+    </sourcefile>
+    <counter type="INSTRUCTION" missed="80" covered="324"/>
+    <counter type="COMPLEXITY" missed="11" covered="39"/>
+    <counter type="METHOD" missed="9" covered="37"/>
+    <counter type="CLASS" missed="2" covered="10"/>
+  </package>
+  <counter type="INSTRUCTION" missed="39399" covered="19321"/>
+  <counter type="COMPLEXITY" missed="5517" covered="1444"/>
+  <counter type="METHOD" missed="3382" covered="1120"/>
+  <counter type="CLASS" missed="491" covered="370"/>
+</report>

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -50,9 +50,43 @@ module Danger
         @my_plugin.report(path_a, 'http://test.com/')
 
         expect(@dangerfile.status_report[:markdowns][0].message).to include("| [`com/example/CachedRepository`](http://test.com/com.example/CachedRepository.html) | 50% | 80% | :warning: |")
-
       end
-    
+
+      it 'When the option "fail_no_coverage_data_found" is set to optionally fail, it doesn\'t fail the execution' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_class_coverage_percentage = 80
+        @my_plugin.minimum_project_coverage_percentage = 50
+
+        expect{@my_plugin.report(path_a, fail_no_coverage_data_found: true)}.to_not raise_error(RuntimeError)
+      end
+
+      it 'When this option "fail_no_coverage_data_found" is not set, the execution fails on empty data' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_b.xml"
+
+        @my_plugin.minimum_class_coverage_percentage = 80
+        @my_plugin.minimum_project_coverage_percentage = 50
+
+        expect{@my_plugin.report path_a}.to raise_error(RuntimeError)
+      end
+
+      it 'When this option "fail_no_coverage_data_found" is set to optionally fail, the execution fails on empty data' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_b.xml"
+
+        @my_plugin.minimum_class_coverage_percentage = 80
+        @my_plugin.minimum_project_coverage_percentage = 50
+
+        expect{@my_plugin.report path_a, fail_no_coverage_data_found: true}.to raise_error(RuntimeError)
+      end
+
+      it 'When this option "fail_no_coverage_data_found" is set to optionally warn (not fail), the execution doesn\'t fail on empty data' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_b.xml"
+
+        @my_plugin.minimum_class_coverage_percentage = 80
+        @my_plugin.minimum_project_coverage_percentage = 50
+
+        expect{@my_plugin.report path_a, fail_no_coverage_data_found: false}.to_not raise_error(RuntimeError)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@ RSpec.configure do |config|
   config.tty = true
 end
 
+RSpec::Expectations.configuration.on_potential_false_positives = :nothing
+
 require 'danger_plugin'
 
 # These functions are a subset of https://github.com/danger/danger/blob/master/spec/spec_helper.rb


### PR DESCRIPTION
I needed to use the patch created by @pardom, so I added an option to improve it as you requested it [here](https://github.com/Malinskiy/danger-jacoco/pull/11)