### PR TITLE
Add `prioritize_line_class_coverage` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ jacoco.minimum_class_coverage_map = { # optional (default is empty)
 jacoco.minimum_class_coverage_percentage = 75 # default 0
 jacoco.files_extension = [".java"] # default [".kt", ".java"]
 jacoco.report("path/to/jacoco.xml", "http://jacoco-html-reports/")
+jacoco.prioritize_line_class_coverage = true # default false
 ```
 
 to your `Dangerfile` 

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -26,6 +26,7 @@ module Danger
     attr_accessor :minimum_package_coverage_map
     attr_accessor :minimum_class_coverage_map
     attr_accessor :fail_no_coverage_data_found
+    attr_accessor :prioritize_line_class_coverage
 
     # Initialize the plugin with configured parameters or defaults
     def setup
@@ -34,6 +35,7 @@ module Danger
       @minimum_package_coverage_map = {} unless minimum_package_coverage_map
       @minimum_class_coverage_map = {} unless minimum_class_coverage_map
       @files_extension = ['.kt', '.java'] unless files_extension
+      @prioritize_line_class_coverage = false unless prioritize_line_class_coverage
     end
 
     # Parses the xml output of jacoco to Ruby model classes
@@ -161,7 +163,11 @@ module Danger
       counters = jacoco_class.counters
       branch_counter = counters.detect { |e| e.type.eql? 'BRANCH' }
       line_counter = counters.detect { |e| e.type.eql? 'LINE' }
-      counter = branch_counter.nil? ? line_counter : branch_counter
+      if @prioritize_line_class_coverage
+        counter = line_counter
+      else
+        counter = branch_counter.nil? ? line_counter : branch_counter
+      end
 
       if counter.nil?
         no_coverage_data_found_message = "No coverage data found for #{jacoco_class.name}"

--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -163,11 +163,11 @@ module Danger
       counters = jacoco_class.counters
       branch_counter = counters.detect { |e| e.type.eql? 'BRANCH' }
       line_counter = counters.detect { |e| e.type.eql? 'LINE' }
-      if @prioritize_line_class_coverage
-        counter = line_counter
-      else
-        counter = branch_counter.nil? ? line_counter : branch_counter
-      end
+      counter = if @prioritize_line_class_coverage
+                  line_counter
+                else
+                  branch_counter.nil? ? line_counter : branch_counter
+                end
 
       if counter.nil?
         no_coverage_data_found_message = "No coverage data found for #{jacoco_class.name}"

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -158,6 +158,17 @@ module Danger
 
         expect { @my_plugin.report path_a, fail_no_coverage_data_found: false }.to_not raise_error(RuntimeError)
       end
+
+      it 'test with prioritize line class coverage' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_class_coverage_map = { 'com/example/CachedRepository' => 80 }
+        @my_plugin.prioritize_line_class_coverage = true
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include('| `com/example/CachedRepository` | 100% | 80% | :white_check_mark: |')
+      end
     end
   end
 end


### PR DESCRIPTION
Hi @Malinskiy 

Added an option to prioritize LINE (C0) coverage output for each class.
This is because even though the total coverage always outputs C0 coverage, the per-class coverage was prioritizing C1 if C1 was available. This would cause inconsistency, so the option to output C0 coverage was necessary.

The default behavior has been made the same as before, so there is no need for users to do anything after the upgrade. Users only need to set this option if they need it.

Thank you.