### PR TITLE
Regex class coverage support

### DIFF
--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -98,9 +98,7 @@ module Danger
       counter = coverage_counter(jacoco_class)
       unless counter.nil?
         coverage = (counter.covered.fdiv(counter.covered + counter.missed) * 100).floor
-        required_coverage = minimum_class_coverage_map[jacoco_class.name]
-        required_coverage = package_coverage(jacoco_class.name) if required_coverage.nil?
-        required_coverage = minimum_class_coverage_percentage if required_coverage.nil?
+        required_coverage = required_class_coverage(jacoco_class)
         status = coverage_status(coverage, required_coverage)
 
         report_result = {
@@ -111,6 +109,15 @@ module Danger
       end
 
       report_result
+    end
+
+    # Determines the required coverage for the class
+    def required_class_coverage(jacoco_class)
+      key = minimum_class_coverage_map.keys.detect { |k| jacoco_class.name.match(k) } || jacoco_class.name
+      required_coverage = minimum_class_coverage_map[key]
+      required_coverage = package_coverage(jacoco_class.name) if required_coverage.nil?
+      required_coverage = minimum_class_coverage_percentage if required_coverage.nil?
+      required_coverage
     end
 
     # it returns the most suitable coverage by package name to class or nil

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -43,7 +43,7 @@ module Danger
         expect(@dangerfile.status_report[:markdowns][0].message).to include('| `com/example/CachedRepository` | 50% | 100% | :warning: |')
       end
 
-      it 'test regex ' do
+      it 'test regex class coverage' do
         path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
 
         @my_plugin.minimum_project_coverage_percentage = 50

--- a/spec/jacoco_spec.rb
+++ b/spec/jacoco_spec.rb
@@ -43,6 +43,17 @@ module Danger
         expect(@dangerfile.status_report[:markdowns][0].message).to include('| `com/example/CachedRepository` | 50% | 100% | :warning: |')
       end
 
+      it 'test regex ' do
+        path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
+
+        @my_plugin.minimum_project_coverage_percentage = 50
+        @my_plugin.minimum_class_coverage_map = { '.*Repository' => 60 }
+
+        @my_plugin.report path_a
+
+        expect(@dangerfile.status_report[:markdowns][0].message).to include('| `com/example/CachedRepository` | 50% | 60% | :warning: |')
+      end
+
       it 'test with package coverage' do
         path_a = "#{File.dirname(__FILE__)}/fixtures/output_a.xml"
 


### PR DESCRIPTION
Hey @Malinskiy, this adds support to provide a regex to match on a class. For example, at Instacart we want to enforce coverage of a specific class type (`Formula`), and this would allow us to specify a regex pattern to match on those classes.