### PR TITLE
Add scala as delimiter for reports.

### DIFF
--- a/lib/jacoco/plugin.rb
+++ b/lib/jacoco/plugin.rb
@@ -59,7 +59,7 @@ module Danger
     # Java => blah/blah/java/slashed_package/Source.java
     # Kotlin => blah/blah/kotlin/slashed_package/Source.kt
     #
-    def report(path, report_url = '', delimiter = %r{/java/|/kotlin/}, fail_no_coverage_data_found: true)
+    def report(path, report_url = '', delimiter = %r{/java/|/kotlin/|/scala/}, fail_no_coverage_data_found: true)
       @fail_no_coverage_data_found = fail_no_coverage_data_found
 
       setup


### PR DESCRIPTION
Adding Scala as a delimiter for reports along with Java and Kotlin

I've tested this on a Scala project with my forked Gem and it works perfectly.